### PR TITLE
Update site.cfg

### DIFF
--- a/site.cfg
+++ b/site.cfg
@@ -144,19 +144,20 @@ eggs =
      plumi.skin
 #    em.taxonomies
 #    unweb.shareit
-#    collective.captcha
+    collective.captcha
 #    Products.LongRequestLogger[standalone]
-#    plone.formwidget.captcha
+    plone.formwidget.captcha
 #    plonetheme.plumigreen
 #    plumi.euclid
+    collective.twitter.accounts
 
 # additional zcml includes - leave empty if unsure
 zcml =
 #     em.skin
 #    em.taxonomies
 #    unweb.shareit
-#    collective.captcha
-#    plone.formwidget.captcha
+    collective.captcha
+    plone.formwidget.captcha
 #    plonetheme.plumigreen
 #    plumi.euclid
 


### PR DESCRIPTION
added viz. allowed two more eggs, complying with previous requests of having captcha, both collective and formwidget (had no specific hint), and collective.twitter.accounts; -- 

ask for verification, since plumi addresses errors after rebuild and subsequent restart.

Apologize for misuse and -understanding of the canonical procedure.
